### PR TITLE
Fixing typology page bugs

### DIFF
--- a/content/planning-framework/overview.mdx
+++ b/content/planning-framework/overview.mdx
@@ -3,11 +3,10 @@ id: 'planning-framework-overview'
 title: 'Planning Framework'
 subtitle: 'Surfacing key questions to shape scientific software development'
 ---
-import { Grid, StepLabel, StepContent } from '@mui/material';
+import { Grid } from '@mui/material';
 import { Hero } from '/src/components/Hero';
 import { PageContainer } from '/src/components/PageContainer';
 import { ContentCard } from '/src/components/ContentCard';
-import { ContentStepper, ContentStep } from '/src/components/ContentStepper';
 import { Link } from 'gatsby';
 
 <Hero>

--- a/content/planning-framework/overview.mdx
+++ b/content/planning-framework/overview.mdx
@@ -8,7 +8,7 @@ import { Hero } from '/src/components/Hero';
 import { PageContainer } from '/src/components/PageContainer';
 import { ContentCard } from '/src/components/ContentCard';
 import { ContentStepper, ContentStep } from '/src/components/ContentStepper';
-import { Link } from '@mui/material';
+import { Link } from 'gatsby';
 
 <Hero>
   The STRUDEL Planning Framework will help scientific teams incorporate UX practices in their software production.
@@ -44,6 +44,6 @@ import { Link } from '@mui/material';
 # Learn more
 More information is coming soon!
 
-Understand the background by reviewing our initial <Link href="/planning-framework/typology">typology</Link>.
+Understand the background by reviewing our initial <Link to="/planning-framework/typology">typology</Link>.
 
 </PageContainer>

--- a/content/planning-framework/typology.mdx
+++ b/content/planning-framework/typology.mdx
@@ -7,7 +7,6 @@ import { Grid } from '@mui/material';
 import { Hero } from '/src/components/Hero';
 import { PageContainer } from '/src/components/PageContainer';
 import { ContentCard } from '/src/components/ContentCard';
-import { StaticImage } from 'gatsby-plugin-image';
 
 <Hero>
     STRUDEL research and design developed a wide ranging sociotechnical typology to categorize aspects of scientific software development.
@@ -53,9 +52,6 @@ The STRUDEL Typology is constructed to be usable by anyone involved with scienti
 
 ## Typology Dimensions
 
-<StaticImage
-alt="STRUDEL Typology overview"
-src="../images/typology-infographic-v0.png"
-/>
+![Infographic of the Typology Dimensions](../images/typology-infographic-v0.png)
 
 </PageContainer>

--- a/content/planning-framework/typology.mdx
+++ b/content/planning-framework/typology.mdx
@@ -3,12 +3,10 @@ id: 'planning-framework-typology'
 title: 'STRUDEL Typology'
 subtitle: 'Classifying scientific software development work'
 ---
-import { Box, Grid, StepLabel, StepContent } from '@mui/material';
+import { Grid } from '@mui/material';
 import { Hero } from '/src/components/Hero';
 import { PageContainer } from '/src/components/PageContainer';
 import { ContentCard } from '/src/components/ContentCard';
-import { ContentStepper, ContentStep } from '/src/components/ContentStepper';
-import { Link } from '@mui/material';
 import { StaticImage } from 'gatsby-plugin-image';
 
 <Hero>
@@ -55,7 +53,7 @@ The STRUDEL Typology is constructed to be usable by anyone involved with scienti
 
 ## Typology Dimensions
 
-<img
+<StaticImage
 alt="STRUDEL Typology overview"
 src="../images/typology-infographic-v0.png"
 />

--- a/src/components/StyledMarkdown.tsx
+++ b/src/components/StyledMarkdown.tsx
@@ -23,6 +23,9 @@ export const StyledMarkdown: React.FC<PropsWithChildren> = ({ children }) => {
         '& *:last-child': {
           marginBottom: 0,
         },
+        '& a, & a:visited': {
+          color: 'primary.main'
+        }
       }}
     >
       {children}


### PR DESCRIPTION
Updated based on comments in other branch PR that @codytodonnell identified.

Switching to gatsby link instead of mui/material makes the link on overview page invisible. Not sure where the styling issue is.

Switched typology page image to StaticImage but nothing loads still.