### PR TITLE
Update gh pages action

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -77,10 +77,10 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Gatsby
         env:
-          PREFIX_PATHS: 'true'
+          PREFIX_PATHS: "true"
         run: ${{ steps.detect-package-manager.outputs.manager }} run build --prefix-paths
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
Update the github action for uploading to github pages because the previous version has been deprecated. 

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.